### PR TITLE
Fix OpenAI init parameter

### DIFF
--- a/test_api_key.py
+++ b/test_api_key.py
@@ -9,7 +9,7 @@ openai.api_key = os.getenv("OPENAI_KEY")
 
 def test_api_key():
     try:
-        llm = OpenAI(api_key=openai.api_key)
+        llm = OpenAI(openai_api_key=openai.api_key)
 
         response = llm("Hello, world!")
         print("API key is valid.")


### PR DESCRIPTION
## Summary
- use `openai_api_key` param when initializing `OpenAI` in `test_api_key.py`

## Testing
- `python test_api_key.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6861b1cabd1c8332b959b8a6cc2059bd